### PR TITLE
[FE] Refactor/fix cross browsing issue

### DIFF
--- a/client/src/Components/Address/index.tsx
+++ b/client/src/Components/Address/index.tsx
@@ -5,6 +5,7 @@ import useInput from "@/hooks/useInput";
 import { useState, useEffect } from "react";
 import ModalWrapper from "../ModalWrapper";
 import { AddressType, PostcodeType } from "@/shared/type";
+import { gap } from "@/styles/theme";
 
 export type ChangeAddressHandler = (address: AddressType) => {};
 
@@ -71,7 +72,7 @@ const AddressWrapper = styled.div`
   max-width: 50rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  ${gap("1rem", "column")}
   ${({ theme }) => theme.borderRadius.small}
 
   input {
@@ -99,11 +100,11 @@ const AddressWrapper = styled.div`
   .address-search {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    ${gap("1rem", "column")}
     &__upper {
       display: flex;
       flex-direction: row;
-      gap: 1rem;
+      ${gap("1rem")}
     }
     input {
       width: 100%;

--- a/client/src/Components/Footer/index.tsx
+++ b/client/src/Components/Footer/index.tsx
@@ -1,3 +1,4 @@
+import { gap } from "@/styles/theme";
 import styled from "styled-components";
 
 const Footer = () => {
@@ -38,14 +39,14 @@ const Wrapper = styled.div`
   padding-bottom: 8rem;
   background-color: ${({ theme }) => theme.color.light_grey1};
   ${({ theme }) => theme.flexCenter};
-  gap: 10rem;
+  ${gap("10rem")}
   img {
     margin-bottom: 5rem;
   }
   b {
     ${({ theme }) => theme.font.medium};
     display: flex;
-    gap: 5rem;
+    ${gap("rem")}
     font-weight: 700;
   }
   p {

--- a/client/src/Components/Header/index.tsx
+++ b/client/src/Components/Header/index.tsx
@@ -4,6 +4,7 @@ import { ReactChild, useState } from "react";
 import styled from "styled-components";
 import SearchBar from "./Search";
 import Menu from "./Menu";
+import { gap } from "@/styles/theme";
 
 const Header = ({ children }: { children?: ReactChild }) => {
   const [isLogined, setIsLogined] = useState(false);
@@ -53,7 +54,7 @@ const TopWrapper = styled.div`
   .header__buttons {
     display: flex;
     flex-direction: row;
-    gap: 5rem;
+    ${gap("5rem")}
 
     a:hover {
       font-weight: bolder;

--- a/client/src/Components/Input/InputSection.tsx
+++ b/client/src/Components/Input/InputSection.tsx
@@ -1,4 +1,5 @@
 import { InputType } from "@/hooks/useInput";
+import { gap } from "@/styles/theme";
 import { ReactElement } from "react";
 import styled from "styled-components";
 import Input from ".";
@@ -32,7 +33,8 @@ const SectionWrapper = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+
+  ${gap("1rem", "column")}
 
   .form__title {
     ${({ theme }) => theme.font.medium}

--- a/client/src/Components/Input/ValidationInput.tsx
+++ b/client/src/Components/Input/ValidationInput.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { useState } from "react";
 import { InputType } from "@/hooks/useInput";
 import { ValidationType } from "@/hooks/useValidation";
+import { gap } from "@/styles/theme";
 
 type VIPropsType = {
   input: InputType;
@@ -47,7 +48,7 @@ const InputWrapper = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  ${gap("1rem", "column")}
 
   input {
     box-sizing: border-box;

--- a/client/src/Components/ItemInfoBox/index.tsx
+++ b/client/src/Components/ItemInfoBox/index.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import Checkbox from "@/Components/Checkbox";
 import { convertToKRW } from "@/utils/util";
+import { gap } from "@/styles/theme";
 
 export type ItemInfoBoxProps = {
   name: string;
@@ -57,7 +58,7 @@ const Wrapper = styled.div`
   .info {
     display: flex;
     align-items: flex-start;
-    gap: 2rem;
+    ${gap("2rem")}
     &__name {
       ${({ theme }) => theme.font.large};
     }
@@ -74,7 +75,7 @@ const Wrapper = styled.div`
     ${({ theme }) => theme.flexCenter};
     font-weight: 700;
     justify-content: flex-end;
-    gap: 2rem;
+    ${gap("2rem")}
   }
 `;
 

--- a/client/src/Pages/Cart/CartBox.tsx
+++ b/client/src/Pages/Cart/CartBox.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Button from "@/Components/Button";
+import { gap } from "@/styles/theme";
 
 const CartBox = () => {
   return (
@@ -47,7 +48,7 @@ const Result = styled.div`
   background: ${({ theme }) => theme.color.background};
   border-radius: 1rem;
   padding: 3rem 2rem;
-  gap: 2rem;
+  ${gap("2rem", "column")}
   width: 40rem;
   & > div {
     ${({ theme }) => theme.flexCenter};

--- a/client/src/Pages/Cart/index.tsx
+++ b/client/src/Pages/Cart/index.tsx
@@ -7,6 +7,7 @@ import CartBox from "./CartBox";
 import { buyItems } from "@/shared/dummy";
 import { Arrow } from "@/assets";
 import Checkbox from "@/Components/Checkbox";
+import { gap } from "@/styles/theme";
 
 const CartPage = () => {
   return (
@@ -62,13 +63,13 @@ const Content = styled.div`
   display: flex;
   align-items: flex-start;
   width: 100%;
-  gap: 3rem;
+  ${gap("3rem")}
   .items {
     padding-bottom: 5rem;
     display: flex;
     flex-direction: column;
     width: 100%;
-    gap: 2rem;
+    ${gap("2rem", "column")}
   }
 `;
 

--- a/client/src/Pages/Detail/OptionBox.tsx
+++ b/client/src/Pages/Detail/OptionBox.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import ModalWrapper from "@/Components/ModalWrapper";
 import { Triangle } from "@/assets";
 import { convertToKRW } from "@/utils/util";
+import { gap } from "@/styles/theme";
 
 const OptionBox = ({ numValue, handleClickNumVal }) => {
   const [isCartAlertShown, setIsCartAlertShown] = useState(false);
@@ -83,7 +84,7 @@ const Wrapper = styled.div`
     padding: 1.5rem 0;
     &__right {
       ${({ theme }) => theme.flexCenter}
-      gap: 2rem;
+      ${gap("2rem")}
       .num-input {
         ${({ theme }) => theme.flexCenter}
         div {
@@ -128,7 +129,7 @@ const Wrapper = styled.div`
     ${({ theme }) => theme.flexCenter}
     width: 100%;
     justify-content: flex-end;
-    gap: 1rem;
+    ${gap("1rem")}
   }
   .alert {
     width: auto;

--- a/client/src/Pages/Detail/Question/QuestionBox.tsx
+++ b/client/src/Pages/Detail/Question/QuestionBox.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { QuestionType } from "@/shared/type";
 import dayjs from "dayjs";
+import { gap } from "@/styles/theme";
 
 const QuestionBox = (Question: QuestionType) => {
   const isAnswered = Question.answer ? true : false;
@@ -58,7 +59,7 @@ const Header = styled.div`
   ${({ theme }) => theme.flexCenter}
   justify-content: flex-start;
   margin-top: 1rem;
-  gap: 1rem;
+  ${gap("1rem")}
   .date {
     color: ${({ theme }) => theme.color.grey1};
   }

--- a/client/src/Pages/Detail/Question/QuestionModal.tsx
+++ b/client/src/Pages/Detail/Question/QuestionModal.tsx
@@ -3,6 +3,7 @@ import useInput from "@/hooks/useInput";
 import styled from "styled-components";
 import ModalWrapper from "@/Components/ModalWrapper";
 import { useState } from "react";
+import { gap } from "@/styles/theme";
 
 const QuestionModal = ({ handleModalOpen }) => {
   const reviewVal = useInput("");
@@ -56,7 +57,7 @@ const Wrapper = styled.form`
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    ${gap("1rem", "column")}
     &__label {
       ${({ theme }) => theme.font.medium};
     }

--- a/client/src/Pages/Detail/Review/ReviewBox.tsx
+++ b/client/src/Pages/Detail/Review/ReviewBox.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { ReviewType } from "@/shared/type";
 import Rating from "@/Components/Rating";
+import { gap } from "@/styles/theme";
 
 const ReviewBox = (review: ReviewType) => {
   return (
@@ -36,7 +37,7 @@ const Wrapper = styled.div`
     padding: 2rem 1.5rem;
     display: flex;
     flex-direction: column;
-    gap: 3rem;
+    ${gap("3rem", "column")}
 
     .content-img {
       max-width: 80%;
@@ -53,10 +54,10 @@ const Header = styled.div`
   ${({ theme }) => theme.flexCenter}
   flex-direction: column;
   align-items: flex-start;
-  gap: 1rem;
+  ${gap("1rem", "column")}
   .info {
     ${({ theme }) => theme.flexCenter}
-    gap: 1rem;
+    ${gap("1rem", "column")}
   }
 `;
 

--- a/client/src/Pages/Detail/Review/ReviewModal.tsx
+++ b/client/src/Pages/Detail/Review/ReviewModal.tsx
@@ -3,6 +3,7 @@ import Rating from "@/Components/Rating";
 import useInput from "@/hooks/useInput";
 import styled from "styled-components";
 import ModalWrapper from "@/Components/ModalWrapper";
+import { gap } from "@/styles/theme";
 
 const ReviewModal = ({ handleModalOpen }) => {
   const reviewVal = useInput("");
@@ -47,7 +48,7 @@ const Wrapper = styled.form`
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    ${gap("1rem", "column")}
     &__label {
       ${({ theme }) => theme.font.medium};
     }

--- a/client/src/Pages/Detail/Review/index.tsx
+++ b/client/src/Pages/Detail/Review/index.tsx
@@ -5,6 +5,7 @@ import ReviewBox from "./ReviewBox";
 import { useState } from "react";
 import ReviewModal from "./ReviewModal";
 import { reviews } from "@/shared/dummy";
+import { gap } from "@/styles/theme";
 
 const Review = () => {
   const [isModalOpened, setIsModalOpened] = useState(false);
@@ -79,7 +80,7 @@ const Header = styled.div`
   justify-content: space-between;
   .left {
     ${({ theme }) => theme.flexCenter};
-    gap: 4rem;
+    ${gap("4rem")}
   }
   .progress {
     background-color: ${({ theme }) => theme.color.background};
@@ -109,7 +110,7 @@ const Filter = styled.div`
 
   .buttons {
     ${({ theme }) => theme.flexCenter};
-    gap: 1.5rem;
+    ${gap("1.5rem")}
     & > * {
       cursor: pointer;
     }

--- a/client/src/Pages/Detail/index.tsx
+++ b/client/src/Pages/Detail/index.tsx
@@ -9,6 +9,7 @@ import Question from "./Question";
 import Footer from "@/Components/Footer";
 import Guide from "./Guide";
 import ZoomModal from "./ZoomModal";
+import { gap } from "@/styles/theme";
 
 const topHeight = 740;
 
@@ -177,7 +178,7 @@ const InfoBox = styled.div`
   width: 100%;
   height: 50rem;
   box-sizing: border-box;
-  gap: 9rem;
+  ${gap("5rem")}
   .thumbnail {
     width: 50rem;
     height: 100%;

--- a/client/src/Pages/Login.tsx
+++ b/client/src/Pages/Login.tsx
@@ -4,6 +4,7 @@ import Input from "@/Components/Input";
 import { ETLink } from "@/Router";
 import Button from "@/Components/Button";
 import useInput from "@/hooks/useInput";
+import { gap } from "@/styles/theme";
 
 const LoginPage = () => {
   const id = useInput("");
@@ -135,7 +136,7 @@ const Form = styled.form`
   height: auto;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  ${gap("2rem", "column")}
 `;
 
 export default LoginPage;

--- a/client/src/Pages/Main/BannerSection/Banner.tsx
+++ b/client/src/Pages/Main/BannerSection/Banner.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { ETLink } from "@/Router";
 import { ItemBannerType } from "@/shared/type";
+import { gap } from "@/styles/theme";
 
 type BannerPropsType = {
   items: ItemBannerType[];
@@ -62,7 +63,7 @@ const BannerWrapper = styled.div`
     flex-direction: row;
     align-items: flex-end;
     justify-content: flex-end;
-    gap: 2rem;
+    ${gap("3rem")}
     color: white;
   }
 

--- a/client/src/Pages/Main/GiftSection/Gift.tsx
+++ b/client/src/Pages/Main/GiftSection/Gift.tsx
@@ -1,6 +1,7 @@
 import { ItemBannerType } from "@/shared/type";
 import { ETLink } from "@/Router";
 import styled from "styled-components";
+import { gap } from "@/styles/theme";
 
 const GiftItem = ({ item }: { item: ItemBannerType }) => (
   <ItemWrapper isWhite={item.isWhite}>
@@ -36,7 +37,7 @@ const ItemWrapper = styled.div<{ isWhite: boolean }>`
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem;
+    ${gap("0.5rem", "column")}
     padding: 2rem;
     background: ${({ isWhite }) =>
       isWhite

--- a/client/src/Pages/Main/GiftSection/GiftList.tsx
+++ b/client/src/Pages/Main/GiftSection/GiftList.tsx
@@ -1,3 +1,4 @@
+import { gap } from "@/styles/theme";
 import styled from "styled-components";
 import GiftItem from "./Gift";
 
@@ -15,7 +16,7 @@ const GiftListWrapper = styled.ul`
   display: flex;
   flex-direction: row;
   flex: 1 1 50%;
-  gap: 2rem;
+  ${gap("2rem")}
 `;
 
 export default GiftList;

--- a/client/src/Pages/Main/ReviewSection/ReviewList.tsx
+++ b/client/src/Pages/Main/ReviewSection/ReviewList.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import ReviewBox from "@/Pages/Detail/Review/ReviewBox";
 import { ReviewType } from "@/shared/type";
 import { ETLink } from "@/Router";
+import { gap } from "@/styles/theme";
 
 const ReviewList = ({ reviews }: { reviews: ReviewType[] }) => (
   <ReviewListWrapper>
@@ -19,7 +20,7 @@ const ReviewListWrapper = styled.ul`
   width: 100%;
   display: flex;
   flex-direction: row;
-  gap: 2rem;
+  ${gap("2rem")}
 
   li {
     width: 100%;
@@ -28,7 +29,7 @@ const ReviewListWrapper = styled.ul`
       display: flex;
       flex-direction: column-reverse;
       border: none;
-      gap: 2rem;
+      ${gap("2rem", "column-reverse")}
 
       & > div {
         flex-direction: column-reverse;
@@ -48,7 +49,7 @@ const ReviewListWrapper = styled.ul`
       background: none;
       padding: 0;
       justify-content: flex-start;
-      gap: 2rem;
+      ${gap("2rem", "column")}
       .content-img {
         ${({ theme }) => theme.borderRadius.small}
         width: 100%;

--- a/client/src/Pages/Main/index.tsx
+++ b/client/src/Pages/Main/index.tsx
@@ -6,6 +6,7 @@ import GiftSection from "./GiftSection";
 import BannerSection from "./BannerSection/";
 import ReviewSection from "./ReviewSection/";
 import ProductSection from "./ProductSection/";
+import { gap } from "@/styles/theme";
 
 const MainPage = () => {
   return (
@@ -32,7 +33,7 @@ const Wrapper = styled(PageWrapper)`
     height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 10rem;
+    ${gap("10rem", "column")}
 
     & > div {
       ${({ theme }) => theme.flexCenter}

--- a/client/src/Pages/Order/AddressBox.tsx
+++ b/client/src/Pages/Order/AddressBox.tsx
@@ -3,6 +3,7 @@ import { AddressType, UserType } from "@/shared/type";
 import Button from "@/Components/Button";
 import { SetStateAction } from "react";
 import { Dispatch } from "react";
+import { gap } from "@/styles/theme";
 
 type AddressBoxProps = {
   setPage: Dispatch<SetStateAction<"select" | "add" | "edit">>;
@@ -39,8 +40,8 @@ const AddressBox = ({ setPage, address, user }: AddressBoxProps) => {
 
 const Wrapper = styled.div`
   display: flex;
-  gap: 1rem;
   flex-direction: column;
+  ${gap("1rem", "column")}
   background: #fff;
   border-radius: 1rem;
   padding: 2rem;
@@ -58,7 +59,7 @@ const Wrapper = styled.div`
     justify-content: space-between;
     & > div {
       display: flex;
-      gap: 1rem;
+      ${gap("1rem")}
     }
   }
 `;

--- a/client/src/Pages/Order/AddressForm.tsx
+++ b/client/src/Pages/Order/AddressForm.tsx
@@ -9,6 +9,7 @@ import ValidationInput from "@/Components/Input/ValidationInput";
 import Address from "@/Components/Address";
 
 import { validatePhoneNumber, VALIDATION_ERR_MSG } from "@/utils/validations";
+import { gap } from "@/styles/theme";
 
 type AddressFormProps = {
   address?: AddressType;
@@ -87,8 +88,8 @@ const AddressForm = ({ address: addressToEdit, user }: AddressFormProps) => {
 
 const Wrapper = styled.div`
   display: flex;
-  gap: 1rem;
   flex-direction: column;
+  ${gap("1rem", "column")}
   background: #fff;
   border-radius: 1rem;
   padding: 2rem;
@@ -111,7 +112,7 @@ const Form = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 3rem;
+  ${gap("3rem", "column")}
   .save-btn {
     position: absolute;
     padding: 2rem;

--- a/client/src/Pages/Order/AddressModal.tsx
+++ b/client/src/Pages/Order/AddressModal.tsx
@@ -7,6 +7,7 @@ import { AddressType } from "@/shared/type";
 import Button from "@/Components/Button";
 import { Back } from "@/assets";
 import AddressForm from "./AddressForm";
+import { gap } from "@/styles/theme";
 
 const AddressModal = ({ closeModal }) => {
   const handleChangeAddress = (address: AddressType) => {
@@ -80,7 +81,7 @@ const Contents = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  ${gap("1rem", "column")}
   background: ${({ theme }) => theme.color.background};
   overflow-y: scroll;
 `;

--- a/client/src/Pages/Order/OrderBox.tsx
+++ b/client/src/Pages/Order/OrderBox.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Button from "@/Components/Button";
+import { gap } from "@/styles/theme";
 
 const OrderBox = () => {
   return (
@@ -47,7 +48,7 @@ const Result = styled.div`
   background: ${({ theme }) => theme.color.background};
   border-radius: 1rem;
   padding: 3rem 2rem;
-  gap: 2rem;
+  ${gap("2rem", "column")}
   width: 40rem;
   & > div {
     ${({ theme }) => theme.flexCenter};

--- a/client/src/Pages/Order/index.tsx
+++ b/client/src/Pages/Order/index.tsx
@@ -19,6 +19,7 @@ import {
   VALIDATION_ERR_MSG,
 } from "@/utils/validations";
 import { sampleUser } from "@/shared/dummy";
+import { gap } from "@/styles/theme";
 
 const OrderPage = () => {
   const email = useInput("");
@@ -167,7 +168,7 @@ const Content = styled.div`
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
-  gap: 8rem;
+  ${gap("8rem", "column")}
   margin-top: 4rem;
 `;
 
@@ -176,7 +177,7 @@ const Info = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2rem;
+  ${gap("2rem", "column")}
   .label {
     ${({ theme }) => theme.flexCenter};
     ${({ theme }) => theme.font.large};
@@ -190,7 +191,7 @@ const Info = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 3rem;
+    ${gap("3rem", "column")}
     width: 30rem;
   }
   div {
@@ -200,12 +201,12 @@ const Info = styled.div`
     display: flex;
     flex-direction: column;
     width: 100%;
-    gap: 2rem;
+    ${gap("2rem", "column")}
   }
   .address-info {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    ${gap("1rem", "column")}
     .name {
       ${({ theme }) => theme.font.large};
     }

--- a/client/src/Pages/Signup.tsx
+++ b/client/src/Pages/Signup.tsx
@@ -15,6 +15,7 @@ import {
   validatePhoneNumber,
   VALIDATION_ERR_MSG,
 } from "@/utils/validations";
+import { gap } from "@/styles/theme";
 
 const SignupPage = () => {
   const email = useInput("");
@@ -150,13 +151,13 @@ const SignupForm = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 3rem;
+  ${gap("3rem", "column")}
 
   .signup__buttons {
     width: 100%;
     display: flex;
     flex-direction: row;
-    gap: 5rem;
+    ${gap("5rem")}
 
     a {
       width: 100%;

--- a/client/src/shared/styled.ts
+++ b/client/src/shared/styled.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { LINE_LINK } from "@/assets";
+import { gap } from "@/styles/theme";
 
 export const PageWrapper = styled.div`
   position: relative;
@@ -46,12 +47,14 @@ export const SignatureLine = styled.div<{ type: string }>`
 export const ItemList = styled.ul`
   display: flex;
   margin-top: 2rem;
-  gap: 1rem;
   justify-content: space-between;
   width: 100%;
+
   & > * {
     flex: 1;
   }
+
+  ${gap("1rem")}
 `;
 
 export const ItemWrapList = styled.ul`

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -61,6 +61,27 @@ const tags = {
   `,
 };
 
+const calculateMargin = (
+  gap: string,
+  direction: "row" | "column" | "column-reverse"
+) => {
+  if (direction === "row") return `margin-left: ${gap}`;
+  if (direction === "column") return `margin-top: ${gap}`;
+  if (direction === "column-reverse") return `margin-bottom: ${gap}`;
+  return "";
+};
+
+export const gap = (
+  gapLength: string,
+  direction: "row" | "column" | "column-reverse" = "row"
+) => {
+  return css`
+    & > * + * {
+      ${calculateMargin(gapLength, direction)}
+    }
+  `;
+};
+
 export const light: DefaultTheme = {
   color: {
     title_active: "#1e2222",


### PR DESCRIPTION
## :bookmark_tabs: 

this resolves #51 issue.

<img width="1253" alt="스크린샷 2021-08-17 오후 1 24 51" src="https://user-images.githubusercontent.com/35447853/129663423-2ae7f2bc-4208-4856-8d50-1e815b2ed18d.png">

사파리에서 gap 적용이 되지 않아서 margin값으로 변경해주도록 만들었습니다. 🙂

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 사파리에서 gap 적용이 되지 않아서 margin값으로 변경

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 해당 폴리필을 사용하실 때, 두번째 인자로 flex-direction을 넣어 주셔야 정상 작동합니다! (row는 디폴트)
