### PR TITLE
[FE] 라우팅 리펙토링 및 Search, Category React Query 구현 완료

### DIFF
--- a/client/config/webpack.config.common.js
+++ b/client/config/webpack.config.common.js
@@ -1,4 +1,4 @@
-const webpack = require('webpack');
+const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 const dotenv = require("dotenv-webpack");
@@ -63,16 +63,9 @@ module.exports = (env) => {
       new HtmlWebpackPlugin({
         template: "./src/index.html",
       }),
-      /*new dotenv({
+      new dotenv({
         path: env.production ? "./env/.env" : "./env/dev.env",
-      }),*/
-      new webpack.DefinePlugin({
-        'process.env.BASE_URL': JSON.stringify(process.env.BASE_URL),
-        'process.env.IMG_URL': JSON.stringify(process.env.IMG_URL),
-        'process.env.DEMO_EMAIL': JSON.stringify(process.env.DEMO_EMAIL),
-        'process.env.DEMO_PW': JSON.stringify(process.env.DEMO_PW)
       }),
-      new webpack.EnvironmentPlugin(['BASE_URL', 'IMG_URL', 'DEMO_EMAIL', 'DEMO_PW']),
       new forkTsCheckerWebpackPlugin(),
     ],
   };

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "styled-components": "^5.3.0",
     "styled-reset": "^4.3.4",
     "ts-loader": "^9.2.5",
-    "webpack": "^5.49.0",
+    "webpack": "^5.51.1",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import MainPage from "@/Pages/Main";
 import LoginPage from "@/Pages/Login";
-import { Router, Route } from "./Router";
+import { Router, Route, PageComponentType, RouteSetType } from "./Router";
 import CategoryPage from "./Pages/Category";
 import DetailPage from "./Pages/Detail";
 import CartPage from "./Pages/Cart";
@@ -20,19 +20,17 @@ import Alert from "./Components/Alert";
 import { verifyToken } from "./api/auth";
 import SearchPage from "./Pages/Search";
 
-type route = [string, JSX.Element, boolean?];
-
-const routes: route[] = [
-  ["/", <MainPage />, true],
-  ["/login", <LoginPage />, true],
-  ["/signup", <SignupPage />],
-  ["/category", <CategoryPage />],
-  ["/order", <OrderPage />, true],
-  ["/order/success", <OrderSuccess />],
-  ["/detail", <DetailPage />],
-  ["/cart", <CartPage />],
-  ["/mypage", <MyPage />],
-  ["/search", <SearchPage />],
+const routes: RouteSetType[] = [
+  ["/", MainPage, true],
+  ["/login", LoginPage, true],
+  ["/signup", SignupPage],
+  ["/category", CategoryPage],
+  ["/order", OrderPage, true],
+  ["/order/success", OrderSuccess],
+  ["/detail", DetailPage],
+  ["/cart", CartPage],
+  ["/mypage", MyPage],
+  ["/search", SearchPage],
 ];
 
 const App = () => {
@@ -71,10 +69,13 @@ const App = () => {
       </button>
 
       <Router>
-        {routes.map(([path, component, exact]: route) => (
-          <Route path={path} exact={exact ?? false} key={path}>
-            {component}
-          </Route>
+        {routes.map(([path, component, exact]: RouteSetType) => (
+          <Route
+            path={path}
+            exact={exact ?? false}
+            key={path}
+            component={component}
+          />
         ))}
       </Router>
       <Alert />

--- a/client/src/Components/Header/Menu/index.tsx
+++ b/client/src/Components/Header/Menu/index.tsx
@@ -89,7 +89,7 @@ const Menu = () => {
           <li key={idx}>
             <Link
               key={idx}
-              to={`/category?main_id=${currentCategoryIndex}&sub_id=${idx}`}
+              to={`/category?category=${categories[currentCategoryIndex].name}&subCategory=${category.name}`}
             >
               {category.name}
             </Link>

--- a/client/src/Components/ProductList/index.tsx
+++ b/client/src/Components/ProductList/index.tsx
@@ -8,7 +8,7 @@ interface ProductListProps {
 
 const ProductList = ({ products }: ProductListProps) => (
   <ProductWrapList>
-    {products.map((product: ProductElementType) => (
+    {products?.map((product: ProductElementType) => (
       <Item {...product} key={product.id} />
     ))}
   </ProductWrapList>

--- a/client/src/Pages/Category/index.tsx
+++ b/client/src/Pages/Category/index.tsx
@@ -2,8 +2,11 @@ import Header from "@/Components/Header";
 import { PageWrapper, Contents } from "@/shared/styled";
 import styled from "styled-components";
 import Footer from "@/Components/Footer";
+import { useProducts } from "@/api/products";
+import ProductList from "@/Components/ProductList";
 
-const CategoryPage = () => {
+const CategoryPage = ({ params }) => {
+  const { data: products } = useProducts(params);
   return (
     <Wrapper>
       <Header />
@@ -18,6 +21,7 @@ const CategoryPage = () => {
             <div className="buttons__btn">높은가격순</div>
           </div>
         </Filter>
+        <ProductList products={products} />
       </Contents>
       <Footer />
     </Wrapper>

--- a/client/src/Pages/Search/index.tsx
+++ b/client/src/Pages/Search/index.tsx
@@ -2,17 +2,45 @@ import Header from "@/Components/Header";
 import { PageWrapper, Contents } from "@/shared/styled";
 import styled from "styled-components";
 import Footer from "@/Components/Footer";
+import { useSearchProducts } from "@/api/search";
+import ProductList from "@/Components/ProductList";
 
-const SearchPage = () => {
+const SearchPage = ({ params }) => {
+  const { data: products } = useSearchProducts(params.keyword);
   return (
     <Wrapper>
       <Header />
-      <Contents></Contents>
+      <Contents>
+        <div className="search-page__keyword">
+          <span>{params.keyword}</span>
+          검색결과 {products?.length ?? 0}건
+        </div>
+        {(!products || products.length === 0) && (
+          <div className="search-page__no-result">검색결과가 없습니다</div>
+        )}
+        <ProductList products={products} />
+      </Contents>
       <Footer />
     </Wrapper>
   );
 };
 
-const Wrapper = styled(PageWrapper)``;
+const Wrapper = styled(PageWrapper)`
+  ${({ theme }) => theme.flexCenter}
+  .search-page__keyword {
+    ${({ theme }) => theme.font.medium};
+    padding-top: 5rem;
+    span {
+      font-weight: bolder;
+      ${({ theme }) => theme.font.xlarge};
+      color: ${({ theme }) => theme.color.primary3};
+      margin-right: 1rem;
+    }
+  }
+  .search-page__no-result {
+    ${({ theme }) => theme.font.xlarge};
+    padding: 16rem;
+  }
+`;
 
 export default SearchPage;

--- a/client/src/api/products.ts
+++ b/client/src/api/products.ts
@@ -4,6 +4,8 @@ import { useQuery } from "react-query";
 
 // GET /products?order?category?subcategory?keyword? 상품 목록
 export const getProducts = ({ params }) => GET("/products", params);
+export const useProducts = ({ params }) =>
+  useQuery(["product", { params }], () => getProducts(params));
 
 // GET /products/:id 상품 상세 정보
 const getProduct = (id: number): Promise<ProductType> => GET(`/products/${id}`);

--- a/client/src/api/search.ts
+++ b/client/src/api/search.ts
@@ -1,14 +1,22 @@
+import { moveTo } from "@/Router";
 import { ProductType } from "@/shared/type";
 import { GET } from "@/utils/axios";
 import { useQuery } from "react-query";
 
 // GET products/keywords/:keyword
-const getKeywords = (keyword) => GET(`/products/keywords/${keyword}`);
+const getKeywords = (keyword: string) =>
+  keyword.length && GET(`/products/keywords/${keyword}`);
 
 export const useKeywords = (keyword: string) =>
   useQuery(["autoComplete", keyword], () => getKeywords(keyword));
 
 // GET products/search/:keyword
-const getSearchedProducts = (keyword) => GET(`/products/search/${keyword}`);
-export const useSearchProducts = () =>
-  useQuery(["autoComplete"], (keyword) => getSearchedProducts(keyword));
+const getSearchedProducts = (keyword: string) => {
+  if (keyword.length === 0) {
+    moveTo("/");
+    return [];
+  }
+  GET(`/products/search/${keyword}`);
+};
+export const useSearchProducts = (keyword: string) =>
+  useQuery(["autoComplete", keyword], () => getSearchedProducts(keyword));

--- a/client/src/utils/location/index.ts
+++ b/client/src/utils/location/index.ts
@@ -1,4 +1,4 @@
-type URIParameterType = {
+export type URIParameterType = {
   [key: string]: any;
 };
 
@@ -17,7 +17,7 @@ export const encodeParams = (params: URIParameterType): string => {
 
 export const decodeParams = (
   encoded = window.location.search
-): URIParameterType => {
+): URIParameterType | null => {
   const params = {};
 
   const query = encoded.substring(1);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7579,10 +7579,10 @@ webpack-sources@^3.2.0:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz"
   integrity sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==
 
-webpack@^5.49.0:
-  version "5.50.0"
-  resolved "https://registry.npmjs.org/webpack/-/webpack-5.50.0.tgz"
-  integrity sha512-hqxI7t/KVygs0WRv/kTgUW8Kl3YC81uyWQSo/7WUs5LsuRw0htH/fCwbVBGCuiX/t4s7qzjXFcf41O8Reiypag==
+webpack@^5.51.1:
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.51.1.tgz#41bebf38dccab9a89487b16dbe95c22e147aac57"
+  integrity sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"


### PR DESCRIPTION
## :bookmark_tabs: 라우팅 리펙토링 및 Search, Category React Query 구현 완료

라우팅에서 각 페이지로 location, params를 반환하도록 했고,
그를 이용해서 Search, Category페이지에서 해당 리스트를 받아오도록 React Query 구현 완료했습니다 🙂 

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/35447853/130366172-51df7a69-e0e0-45b0-8747-04c6d8fe7d1a.gif)


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Router에서 각 페이지로 Location, params 넘겨주도록 함
- [x] Router에서 대소문자 구분 없이 링크 이동하도록 수정
- [x] 해당 params를 체크해서, 검색 결과 혹은 해당 카테고리 product 리스트를 받아오도록 구현

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아직 구현중인데 스타일링은 내일 진행해볼게요~!

## 예상 소요시간: 1H 실제 소요시간: 2.5H (라우팅 때문에...)