### PR TITLE
Item wish 디바운스 

### DIFF
--- a/client/src/Components/Header/Search/DropDown/AutoCompleteList/index.tsx
+++ b/client/src/Components/Header/Search/DropDown/AutoCompleteList/index.tsx
@@ -8,7 +8,7 @@ const AutoList = ({ keyword, handleSearch }) => {
   const handleClick = (v) => {
     handleSearch(v);
   };
-  const debouncedSearchInput = useDebounce(keyword, 200);
+  const debouncedSearchInput = useDebounce<string>(keyword, 200);
   const { data: autoList } = useKeywords(debouncedSearchInput);
 
   const generateAutoList = autoList?.map((value, idx) => (

--- a/client/src/Components/ItemInfoBox/index.tsx
+++ b/client/src/Components/ItemInfoBox/index.tsx
@@ -50,7 +50,7 @@ const LoggedInNumInput = ({
   setCartItems: Dispatch<SetStateAction<CartType>>;
 }) => {
   const numValue = useInput(amount.toString());
-  const debouncedNumValue = useDebounce(numValue.value, 200);
+  const debouncedNumValue = useDebounce<string>(numValue.value, 200);
 
   const isLoggedin = useRecoilValue(loginState);
 

--- a/client/src/Pages/Detail/OptionBox.tsx
+++ b/client/src/Pages/Detail/OptionBox.tsx
@@ -8,37 +8,35 @@ import { convertToKRW } from "@/utils/util";
 import { gap, media } from "@/styles/theme";
 import { postCart } from "@/api/carts";
 import { moveTo } from "@/Router";
-import { useRecoilValue } from "recoil";
-import { loginState } from "@/store/state";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { isMyWishInDetail, loginState } from "@/store/state";
 import { CartType, ProductType } from "@/shared/type";
 import { InputType } from "@/hooks/useInput";
-import { postWishProduct, deleteWishProduct } from "@/api/my";
-import { QueryObserverResult } from "react-query";
 import { useCallback } from "react";
 
 type OptionBoxProps = {
   numValue: InputType;
   handleClickNumVal: Function;
   product: ProductType;
-  refetch?: () => Promise<QueryObserverResult<unknown>>;
+  isMyWish: boolean;
 };
 
 const OptionBox = ({
   numValue,
   handleClickNumVal,
   product,
-  refetch,
+  isMyWish,
 }: OptionBoxProps) => {
   const [isCartAlertShown, setIsCartAlertShown] = useState(false);
+  const setIsMyWish = useSetRecoilState(isMyWishInDetail);
 
   const productId = product.id;
   const isLoggedin = useRecoilValue(loginState);
-  const handlePostWish = async () => {
-    product.isWish
-      ? await deleteWishProduct(productId)
-      : await postWishProduct(productId);
-    refetch();
+
+  const handleClickWish = async () => {
+    setIsMyWish((isMyWish) => !isMyWish);
   };
+
   const handlePostCart = async () => {
     try {
       if (isLoggedin && status !== "loading") {
@@ -134,8 +132,8 @@ const OptionBox = ({
       <div className="buttons">
         <div>
           <WishIcon
-            onClick={handlePostWish}
-            className={product.isWish ? "is-wish" : "not-wish"}
+            onClick={handleClickWish}
+            className={isMyWish ? "is-wish" : "not-wish"}
           />
         </div>
         <Button onClick={handlePostCart}>장바구니</Button>
@@ -253,12 +251,14 @@ const Wrapper = styled.div`
     justify-content: flex-end;
     ${gap("1rem")}
     .is-wish {
+      cursor: pointer;
       fill: ${({ theme }) => theme.color.primary1};
       &:hover {
       }
     }
 
     .not-wish {
+      cursor: pointer;
       stroke: ${({ theme }) => theme.color.primary1};
       fill: transparent;
       stroke-width: 2rem;

--- a/client/src/hooks/useDebounce.ts
+++ b/client/src/hooks/useDebounce.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 const DEFAULT_DELAY = 500;
 
-export default (value: string, delay: number = DEFAULT_DELAY) => {
+export default <T>(value: T, delay: number = DEFAULT_DELAY) => {
   const [debouncedValue, setDebounceValue] = useState(value);
 
   useEffect(() => {

--- a/client/src/hooks/useDidMountEffect.ts
+++ b/client/src/hooks/useDidMountEffect.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from "react";
+
+const useDidMountEffect = (func, deps) => {
+  const didMount = useRef(false);
+
+  useEffect(() => {
+    if (didMount.current) func();
+    else didMount.current = true;
+  }, deps);
+};
+
+export default useDidMountEffect;

--- a/client/src/store/state.ts
+++ b/client/src/store/state.ts
@@ -12,3 +12,8 @@ export const loginState = atom({
   key: "isLoggedin",
   default: false,
 });
+
+export const isMyWishInDetail = atom({
+  key: "isMyWishInDetail",
+  default: false,
+});

--- a/server/src/product/application/product-service.ts
+++ b/server/src/product/application/product-service.ts
@@ -24,11 +24,14 @@ export class ProductService {
   ) {}
 
   async getProducts(
-    findQuery: ProductFindQuery
+    findQuery: ProductFindQuery,
+    userId: number
   ): Promise<ProductElementResponse[]> {
     const products = await this.products.findProductsByQueries(findQuery);
 
-    return products.map(ProductElementResponse.of);
+    return products.map((product) =>
+      ProductElementResponse.of(product, userId)
+    );
   }
 
   async getProduct(id: number, userId: number) {

--- a/server/src/product/domain/products.ts
+++ b/server/src/product/domain/products.ts
@@ -36,7 +36,7 @@ export class Products {
 
   async findProductsByQueries(query: ProductFindQuery): Promise<Product[]> {
     return this.productRepository.find({
-      relations: ["options", "images", "detailImages"],
+      relations: ["options", "images", "detailImages", "wishes", "wishes.user"],
       where: generateWhere(query.category, query.subCategory, query.ids),
       order: ORDER_TYPE[query.order],
       skip: ((query.page ?? START_PAGE) - 1) * (query.size ?? PRODUCT_PER_PAGE),

--- a/server/src/product/dto/product-element-response.ts
+++ b/server/src/product/dto/product-element-response.ts
@@ -21,14 +21,17 @@ export class ProductElementResponse {
     this.image = response.image;
   }
 
-  static of(product: Product): ProductElementResponse {
+  static of(product: Product, userId: number): ProductElementResponse {
     const id = product.id,
       name = product.name,
       originPrice = product.price,
       discountRate = product.discountRate,
       amount = product.stock,
       image = product.getThumbnailImage(),
-      price = product.getDiscountedPrice();
+      price = product.getDiscountedPrice(),
+      isWish =
+        product.wishes?.filter((wish) => wish?.user?.id === userId).length !==
+        0;
 
     return new ProductElementResponse({
       id,
@@ -36,7 +39,7 @@ export class ProductElementResponse {
       price,
       originPrice,
       discountRate,
-      isWish: false,
+      isWish,
       amount,
       image,
     });

--- a/server/src/product/presentation/product-controller.ts
+++ b/server/src/product/presentation/product-controller.ts
@@ -31,9 +31,10 @@ export class ProductController {
 
   @Get()
   async getProducts(
-    @Query() query: ProductFindQuery
+    @Query() query: ProductFindQuery,
+    @Body("userId") userId: number
   ): Promise<ProductElementResponse[]> {
-    return await this.productService.getProducts(query);
+    return await this.productService.getProducts(query, userId);
   }
 
   //auto complete


### PR DESCRIPTION
## :bookmark_tabs: wish 디바운스

wish 추가/삭제시 디바운스 적용했습니다.
기존의 react-query로 refetch를 하게 되면 전체 아이템이 리렌더링이 되는 문제가 발견되어 
wish의 뷰 상태를 서버상태에 의존하지 않고 클라이언트에서 자체적으로 관리합니다.

이를 위해 useEffect를 사용하는데 첫렌더링때 불필요한 요청이 아이템 갯수만큼 발생하기 때문에 useDidMountEffect 훅을 만들어사용했습니다. 첫렌더링 이후부터 적용됩니다. 


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] (작업 내역 1)
- [x] (작업 내역 2)
- [x] (작업 내역 3)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- (특이 사항 1)
- (특이 사항 2)
