### PR TITLE
feat: 주문내역 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,7 +30,7 @@ const routes: RouteSetType[] = [
   ["/signup", SignupPage],
   ["/category", CategoryPage],
   ["/order", OrderPage, true],
-  ["/order", OrderResultPage],
+  ["/result", OrderResultPage],
   ["/detail", DetailPage],
   ["/cart", CartPage],
   ["/mypage", MyPage],

--- a/client/src/Components/Input/InputSection/index.tsx
+++ b/client/src/Components/Input/InputSection/index.tsx
@@ -18,7 +18,7 @@ const InputSection = ({ title, input, brief, children }: FormSectionType) => {
       {brief && <small className="form__brief">{brief}</small>}
       {input ? (
         <Input
-          defaultValue={input.value}
+          value={input.value}
           onChange={input.onChange}
           placeholder={title}
         />

--- a/client/src/Components/Input/index.tsx
+++ b/client/src/Components/Input/index.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 type InputType = {
   placeholder?: string;
   required?: boolean;
-  defaultValue: string;
+  value: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
   onBlur?: ChangeEventHandler<HTMLInputElement>;
   type?: string;
@@ -14,20 +14,14 @@ type InputType = {
 const Input = ({
   placeholder,
   required = true,
-  defaultValue,
+  value,
   onChange,
   onBlur,
   type = "text",
   className,
 }: InputType) => (
   <Container
-    className={className}
-    placeholder={placeholder}
-    required={required}
-    defaultValue={defaultValue}
-    onChange={onChange}
-    onBlur={onBlur}
-    type={type}
+    {...{ className, placeholder, required, value, onChange, onBlur, type }}
     autoComplete="off"
   />
 );

--- a/client/src/Components/ItemInfoBox/CartSelects.tsx
+++ b/client/src/Components/ItemInfoBox/CartSelects.tsx
@@ -74,9 +74,7 @@ const CartSelects = ({
   }, [debouncedNumValue, optionId]);
 
   const RenderNumInput = useCallback(() => {
-    return (
-      <NumInput defaultValue={numValue.value} onChange={numValue.onChange} />
-    );
+    return <NumInput value={numValue.value} onChange={numValue.onChange} />;
   }, [numValue.value]);
 
   return (
@@ -105,7 +103,7 @@ const CartSelects = ({
             onChange={(e) => {
               setOptionId(parseInt(e.target.value));
             }}
-            defaultValue={optionId}
+            value={optionId}
           >
             {options.map((option) => (
               <option key={option.id} value={option.id}>

--- a/client/src/Components/ItemInfoBox/index.tsx
+++ b/client/src/Components/ItemInfoBox/index.tsx
@@ -102,6 +102,7 @@ const ItemInfoBox = ({
       );
     return (
       <div className="info__amount">
+        <span className="info__option">{option}</span>
         {optionValue} {amount}개
       </div>
     );
@@ -170,6 +171,10 @@ const Wrapper = styled.div`
     }
     &__amount {
       margin-top: 3rem;
+    }
+    &__option {
+      font-weight: 800;
+      margin-right: 0.5rem;
     }
     ${media.mobile} {
       ${gap("1rem")}

--- a/client/src/Pages/Detail/OptionBox.tsx
+++ b/client/src/Pages/Detail/OptionBox.tsx
@@ -39,9 +39,7 @@ const OptionBox = ({
   };
 
   const RenderNumInput = useCallback(() => {
-    return (
-      <NumInput defaultValue={numValue.value} onChange={numValue.onChange} />
-    );
+    return <NumInput value={numValue.value} onChange={numValue.onChange} />;
   }, [numValue.value]);
 
   // 상품옵션
@@ -147,7 +145,7 @@ const OptionBox = ({
                   onChange={(e) => {
                     setProductOptionId(parseInt(e.target.value));
                   }}
-                  defaultValue={productOptionId}
+                  value={productOptionId}
                 >
                   {product.options.map((option) => (
                     <option key={option.id} value={option.id}>

--- a/client/src/Pages/Detail/Question/index.tsx
+++ b/client/src/Pages/Detail/Question/index.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import QuestionModal from "./QuestionModal";
 import { useProductQuestions } from "@/api/products";
 import { gap } from "@/styles/theme";
+import NoData from "@/Components/NoData";
 
 const Question = () => {
   const [isModalOpened, setIsModalOpened] = useState(false);
@@ -42,9 +43,15 @@ const Question = () => {
           </Button>
         </Header>
         <QuestionsWrapper>
-          {questions.map((qna, idx) => (
-            <QuestionBox question={qna} key={idx} />
-          ))}
+          {questions.length > 0 ? (
+            questions.map((qna, idx) => (
+              <QuestionBox question={qna} key={idx} />
+            ))
+          ) : (
+            <div className="no-data">
+              <NoData />
+            </div>
+          )}
         </QuestionsWrapper>
         {isModalOpened && (
           <QuestionModal submitType="post" {...{ handleModalOpen, refetch }} />
@@ -57,6 +64,10 @@ const Question = () => {
 const QuestionsWrapper = styled.div`
   margin-top: 3rem;
   ${gap("3rem", "column")}
+
+  .no-data {
+    width: 30%;
+  }
 `;
 
 const Header = styled.div`

--- a/client/src/Pages/Detail/Review/index.tsx
+++ b/client/src/Pages/Detail/Review/index.tsx
@@ -8,6 +8,7 @@ import Checkbox from "@/Components/Checkbox";
 import { useEffect } from "react";
 import useDebounce from "@/hooks/useDebounce";
 import Rating from "@/Components/Rating";
+import NoData from "@/Components/NoData";
 
 const Review = () => {
   const pathname = location.pathname.split("detail/")[1];
@@ -119,9 +120,15 @@ const Review = () => {
         </Filter>
 
         <ReviewsWrapper>
-          {reviews.reviews.map((review) => (
-            <ReviewBox key={review.id} {...{ review }} />
-          ))}
+          {reviews.reviews.length > 0 ? (
+            reviews.reviews.map((review) => (
+              <ReviewBox key={review.id} {...{ review }} />
+            ))
+          ) : (
+            <div className="no-data">
+              <NoData />
+            </div>
+          )}
         </ReviewsWrapper>
       </div>
     )
@@ -131,6 +138,10 @@ const Review = () => {
 const ReviewsWrapper = styled.div`
   margin-top: 3rem;
   ${gap("3rem", "column")}
+
+  .no-data {
+    width: 30%;
+  }
 `;
 
 const Header = styled.div`

--- a/client/src/Pages/Login/LoginSection/index.tsx
+++ b/client/src/Pages/Login/LoginSection/index.tsx
@@ -36,13 +36,13 @@ const LoginSection = () => {
       <Input
         className="login-input"
         placeholder="이메일 입력"
-        defaultValue={email.value}
+        value={email.value}
         onChange={email.onChange}
       />
       <Input
         className="login-input"
         placeholder="비밀번호 입력"
-        defaultValue={password.value}
+        value={password.value}
         type="password"
         onChange={password.onChange}
       />

--- a/client/src/Pages/Login/index.tsx
+++ b/client/src/Pages/Login/index.tsx
@@ -6,14 +6,12 @@ import useInput from "@/hooks/useInput";
 import { gap, media } from "@/styles/theme";
 import LoginSection from "./LoginSection";
 import { Back } from "@/assets";
-import { Link } from "@/Router";
+import { Link, moveTo } from "@/Router";
 
 const LoginPage = () => {
-  const name = useInput("");
-  const phoneNumber = useInput("");
+  const orderNum = useInput("");
   const checkLookupable = (): boolean => {
-    //TODO: validion Check하기(?)
-    return name.value.length > 0 && phoneNumber.value.length > 0;
+    return orderNum.value.length > 0;
   };
 
   return (
@@ -23,16 +21,16 @@ const LoginPage = () => {
         <Form>
           <Title>비회원 주문조회 하기</Title>
           <Input
-            placeholder="주문자명"
-            defaultValue={name.value}
-            onChange={name.onChange}
-          />
-          <Input
             placeholder="주문번호"
-            defaultValue={phoneNumber.value}
-            onChange={phoneNumber.onChange}
+            value={orderNum.value}
+            onChange={orderNum.onChange}
           />
-          <Button disabled={!checkLookupable()}>조회하기</Button>
+          <Button
+            disabled={!checkLookupable()}
+            onClick={() => moveTo(`/result/${orderNum.value}`)}
+          >
+            조회하기
+          </Button>
           <span>
             주문번호와 비밀번호를 잊으신 경우, 고객센터로 문의하여 주시기
             바랍니다.

--- a/client/src/Pages/MyPage/ContentArea/contents/UserInfo/index.tsx
+++ b/client/src/Pages/MyPage/ContentArea/contents/UserInfo/index.tsx
@@ -1,20 +1,176 @@
+import { useState, useEffect } from "react";
 import styled from "styled-components";
-
+import InputSection from "@/Components/Input/InputSection";
 import Section from "../../../Section";
+import ValidationInput from "@/Components/Input/ValidationInput";
+import { gap, media } from "@/styles/theme";
+import { useMyDestinations, useMyInfo } from "@/api/my";
+import useInput from "@/hooks/useInput";
+import { convertToPhoneNumber } from "@/utils/util";
+import {
+  validateEmail,
+  validatePhoneNumber,
+  VALIDATION_ERR_MSG,
+} from "@/utils/validations";
+import useValidation from "@/hooks/useValidation";
+import { DestinationType } from "@/shared/type";
 
 const UserInfo = () => {
+  const { status: myInfoStatus, data: myInfo, error } = useMyInfo();
+
+  // form
+  const email = useInput(myInfo?.email ?? "");
+  const addressee = useInput(myInfo?.name ?? "");
+  const phone = useInput(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
+  const emailValidation = useValidation(validateEmail);
+  const nameValidation = useValidation((name: string) => !!name?.length);
+  const phoneValidation = useValidation(validatePhoneNumber);
+
+  useEffect(() => {
+    if (myInfo) {
+      email.setValue(myInfo?.email);
+      addressee.setValue(myInfo?.name);
+      phone.setValue(convertToPhoneNumber(myInfo?.phoneNumber));
+      emailValidation.onCheck(myInfo?.email ?? "");
+      nameValidation.onCheck(myInfo?.name ?? "");
+      phoneValidation.onCheck(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
+    }
+  }, [myInfo]);
+
+  // 배송지
+  const { status: destinationsStatus, data: destinations } =
+    useMyDestinations();
+  const [address, setAddress] = useState<Partial<DestinationType>>();
+
+  useEffect(() => {
+    if (destinationsStatus !== "loading")
+      setAddress(destinations.find((i) => i.isDefault === true));
+  }, [destinations]);
+
+  const [isAddressModalOpened, setIsAddressModalOpened] = useState(false);
+
   return (
     <Wrapper data-testid="test__userinfo">
       <Section
         title="회원정보 변경"
         description="회원 정보를 변경/수정할 수 있습니다."
       >
-        <div>회원정보 변경 </div>
+        <Info>
+          <div className="user-info">
+            <InputSection title="이름">
+              <ValidationInput
+                input={addressee}
+                validation={nameValidation}
+                placeholder="이름"
+                message={VALIDATION_ERR_MSG.INVALID_NAME}
+              />
+            </InputSection>
+            <InputSection title="이메일">
+              <ValidationInput
+                input={email}
+                validation={emailValidation}
+                placeholder="이메일을 입력해주세요"
+                message={VALIDATION_ERR_MSG.INVALID_EMAIL}
+              />
+            </InputSection>
+            <InputSection title="휴대폰 번호" brief="휴대폰 번호를 적어주세요">
+              <ValidationInput
+                input={phone}
+                validation={phoneValidation}
+                placeholder="010-0000-0000"
+                message={VALIDATION_ERR_MSG.INVALID_PHONE}
+              />
+            </InputSection>
+          </div>
+        </Info>
+
+        <Info>
+          <div className="label">
+            배송지
+            <div
+              className="address-btn"
+              onClick={() => setIsAddressModalOpened(true)}
+            >
+              변경
+            </div>
+          </div>
+
+          <div className="address-info">
+            {address ? (
+              <>
+                <div className="name">{address?.name}</div>
+                <div>
+                  {address?.addressee} {address?.phoneNumber}
+                </div>
+                <div>
+                  {address?.address} {address?.detailAddress}
+                </div>
+              </>
+            ) : (
+              <div>배송지를 추가해주세요</div>
+            )}
+          </div>
+        </Info>
       </Section>
     </Wrapper>
   );
 };
 
 const Wrapper = styled.div``;
+
+export const Info = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  ${gap("2rem", "column")}
+  .label {
+    ${({ theme }) => theme.flexCenter};
+    ${({ theme }) => theme.font.large};
+    width: 100%;
+    justify-content: space-between;
+    padding-bottom: 2rem;
+    margin: 2rem 0;
+    border-bottom: 0.1rem solid ${({ theme }) => theme.color.line};
+  }
+  .user-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    ${gap("3rem", "column")}
+    width: 30rem;
+  }
+  div {
+    ${({ theme }) => theme.font.medium};
+  }
+  .items {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    ${gap("2rem", "column")}
+  }
+  .address-info {
+    display: flex;
+    flex-direction: column;
+    ${gap("1rem", "column")}
+    .name {
+      ${({ theme }) => theme.font.large};
+    }
+  }
+  .address-btn {
+    cursor: pointer;
+    :hover {
+      font-weight: bolder;
+      color: ${({ theme }) => theme.color.primary1};
+    }
+  }
+  .payments {
+    display: flex;
+    ${gap("1rem")}
+    &__item {
+      background: #fff;
+    }
+  }
+`;
 
 export default UserInfo;

--- a/client/src/Pages/MyPage/Nav/index.tsx
+++ b/client/src/Pages/MyPage/Nav/index.tsx
@@ -77,13 +77,13 @@ const navItems = [
     title: "나의 상품후기",
     path: "review",
   },
-  // {
-  //   Icon: (props) => (
-  //     <UserIcon width={ICON_SIZE} height={ICON_SIZE} {...props} />
-  //   ),
-  //   title: "회원정보 변경",
-  //   path: "userinfo",
-  // },
+  {
+    Icon: <img src={Review} width={ICON_SIZE} height={ICON_SIZE} />,
+    Gif: <img src={ReviewActive} width={ICON_SIZE} height={ICON_SIZE} />,
+
+    title: "내 정보 수정",
+    path: "userinfo",
+  },
 ];
 
 const NavItem = ({ Icon, Gif, title, isSelected }) => {

--- a/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
+++ b/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import useInput from "@/hooks/useInput";
 import AddressModal from "../AddressModal";
 import ItemInfoBox from "@/Components/ItemInfoBox";
@@ -11,7 +11,6 @@ import {
   validatePhoneNumber,
   VALIDATION_ERR_MSG,
 } from "@/utils/validations";
-import { useEffect } from "react";
 import { useMyDestinations, useMyInfo } from "@/api/my";
 import { DestinationType, ICart, PartialCart } from "@/shared/type";
 import CartOrderBox from "@/Components/CartOrderBox";

--- a/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
+++ b/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
@@ -79,11 +79,7 @@ const LoggedinContent = () => {
     if (payment === "kakaopay")
       handleKakaoPay(handlePostOrder, orderItems.items);
     else {
-      try {
-        handlePostOrder();
-      } finally {
-        moveTo("/order/success");
-      }
+      handlePostOrder();
     }
   };
 

--- a/client/src/Pages/Order/OrderContent/LoggedoutContent.tsx
+++ b/client/src/Pages/Order/OrderContent/LoggedoutContent.tsx
@@ -68,11 +68,7 @@ const LoggedoutContent = () => {
     if (payment === "kakaopay")
       handleKakaoPay(handlePostOrder, orderItems.items);
     else {
-      try {
-        handlePostOrder();
-      } finally {
-        moveTo("/order/success");
-      }
+      handlePostOrder();
     }
   };
 

--- a/client/src/Pages/Order/index.tsx
+++ b/client/src/Pages/Order/index.tsx
@@ -20,6 +20,7 @@ export const handleKakaoPay = async (
   handlePostOrder: Function,
   items: Partial<ICart>[]
 ) => {
+  console.log("asdf");
   const res = await postPaymentReady({
     cid: "TC0ONETIME",
     item_name:

--- a/client/src/Pages/Order/index.tsx
+++ b/client/src/Pages/Order/index.tsx
@@ -13,6 +13,7 @@ import properties from "@/config/properties";
 import { DestinationType, ICart, PartialCart } from "@/shared/type";
 import { postOrder, postOrderNum } from "@/api/orders";
 import { InputType } from "@/hooks/useInput";
+import { moveTo } from "@/Router";
 
 // 카카오페이
 export const handleKakaoPay = async (
@@ -71,10 +72,12 @@ export const handlePostOrder = (
     const orderNum = `${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${
       orderIds[0]
     }`;
-    console.log("orderNum", orderNum);
+
     orderIds.forEach(async (id) => {
       await postOrderNum(id, orderNum);
     });
+
+    moveTo(`/result/${orderNum}`);
   });
 };
 

--- a/client/src/Pages/OrderResult/index.tsx
+++ b/client/src/Pages/OrderResult/index.tsx
@@ -37,7 +37,7 @@ const OrderResult = () => {
         <div className="title">
           주문번호 {orderNum}
           <div className="title__sub">
-            주문자명과 주문번호로 주문내역을 주회할 수 있습니다.
+            주문번호로 주문내역을 주회할 수 있습니다.
           </div>
         </div>
 
@@ -95,6 +95,9 @@ const Wrapper = styled(PageWrapper)`
       width: 100%;
       padding: 0 5rem;
       box-sizing: border-box;
+    }
+    ${media.mobile} {
+      padding: 0;
     }
   }
 `;

--- a/client/src/Pages/OrderResult/index.tsx
+++ b/client/src/Pages/OrderResult/index.tsx
@@ -2,33 +2,68 @@ import styled from "styled-components";
 import { PageWrapper } from "@/shared/styled";
 import Header from "@/Components/Header";
 import Footer from "@/Components/Footer";
-import Button from "@/Components/Button";
-import { moveTo } from "@/Router";
-import { gap } from "@/styles/theme";
+import { gap, media } from "@/styles/theme";
 import { useOrdersByOrderNum } from "@/api/orders";
 import { useEffect } from "react";
+import properties from "@/config/properties";
+import { moveTo } from "@/Router";
+
+interface OrderType {
+  id: number;
+  optionName: string;
+  optionValue: string;
+  amount: number;
+  status: string;
+  productName: string;
+  product: {
+    id: number;
+    images: { id: string }[];
+  };
+}
 
 const OrderResult = () => {
-  const orderNum = location.pathname.split("order/")[1];
+  const orderNum = location.pathname.split("result/")[1];
   const {
-    status,
+    status: ordersStatus,
     data: orders,
     error,
   } = useOrdersByOrderNum(parseInt(orderNum));
 
-  useEffect(() => {
-    if (orders) console.log(orders);
-  }, [status]);
-
   return (
     <Wrapper>
       <Header />
-      <div className="title">결제가 완료되었습니다</div>
-      <div className="buttons">
-        <Button primary onClick={() => moveTo("/")}>
-          홈화면으로 돌아가기
-        </Button>
-        <Button>주문내역 확인하기</Button>
+
+      <div className="items">
+        <div className="title">
+          주문번호 {orderNum}
+          <div className="title__sub">
+            주문자명과 주문번호로 주문내역을 주회할 수 있습니다.
+          </div>
+        </div>
+
+        {ordersStatus !== "loading" &&
+          orders.map((order: OrderType) => (
+            <OrderBox key={order.id}>
+              <img
+                width="100"
+                src={properties.imgURL + order.product.images[0].id}
+              />
+              <div className="info">
+                <div
+                  onClick={() => moveTo(`/detail/${order.product.id}`)}
+                  className="info__name"
+                >
+                  {order.productName}
+                </div>
+                <div>
+                  <span className="info__option">{order.optionName}</span>
+                  {order.optionValue} {order.amount}개
+                </div>
+              </div>
+
+              <div className="status">{order.status}</div>
+            </OrderBox>
+          ))}
       </div>
       <Footer />
     </Wrapper>
@@ -36,44 +71,79 @@ const OrderResult = () => {
 };
 
 const Wrapper = styled(PageWrapper)`
-  background: #000;
-  color: #fff;
-  ${({ theme }) => theme.flexCenter};
-  flex-direction: column;
+  ${({ theme }) => theme.flexCenter}
+  align-items: flex-start;
 
   .title {
-    position: relative;
-    font-size: 10rem;
-    &::after {
-      content: "결제가 완료되었습니다";
-      position: absolute;
-      white-space: nowrap;
-      top: 0.5rem;
-      left: 0.5rem;
-      color: transparent;
-      -webkit-text-stroke: 0.3rem ${({ theme }) => theme.color.primary1};
-      animation: blink 0.8s linear infinite;
+    margin-top: 10rem;
+    margin-bottom: 5rem;
+    width: 100%;
+    ${({ theme }) => theme.font.xlarge};
+    &__sub {
+      margin-top: 2rem;
+      ${({ theme }) => theme.font.small};
     }
-  }
-  .buttons {
-    margin-top: 5rem;
-    display: flex;
-    ${gap("2rem")}
   }
 
-  @keyframes blink {
-    0% {
-      opacity: 1;
+  .items {
+    /* ${({ theme }) => theme.flexCenter}; */
+    display: flex;
+    flex-direction: column;
+    width: 90rem;
+    ${gap("2rem", "column")};
+    ${media.tablet} {
+      width: 100%;
+      padding: 0 5rem;
+      box-sizing: border-box;
     }
-    30% {
-      opacity: 0;
+  }
+`;
+
+const OrderBox = styled.div`
+  ${({ theme }) => theme.font.medium};
+  width: 100%;
+  background: white;
+  width: 100%;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-sizing: border-box;
+  display: flex;
+  ${media.mobile} {
+    padding: 1rem;
+  }
+  img {
+    width: 7rem;
+    height: 7rem;
+    background-color: ${({ theme }) => theme.color.grey1};
+    object-fit: cover;
+    border-radius: 0.5rem;
+  }
+
+  .info {
+    margin-left: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    width: 100%;
+    ${gap("2rem")}
+    &__name {
+      cursor: pointer;
+      ${({ theme }) => theme.font.large};
     }
-    50% {
-      opacity: 1;
+    &__option {
+      font-weight: 800;
+      margin-right: 0.5rem;
     }
-    100% {
-      opacity: 0;
+    div {
+      margin: 0;
     }
+  }
+
+  .status {
+    font-size: 2rem;
+    font-weight: 800;
+    white-space: nowrap;
   }
 `;
 

--- a/server/src/cart/dto/cart-response.ts
+++ b/server/src/cart/dto/cart-response.ts
@@ -11,6 +11,7 @@ export class CartResponse {
   options: ProductOption[];
   amount: number;
   productId: number;
+  option: string;
 
   static of(cart: Cart): CartResponse {
     const id = cart.id,
@@ -21,6 +22,7 @@ export class CartResponse {
       productOptionId = cart.productOptionId,
       amount = cart.amount,
       productId = cart.product.id,
+      option = cart.product.option,
       options = cart.product.options.map((option) => {
         return {
           id: option.id,
@@ -36,6 +38,7 @@ export class CartResponse {
       deliveryCost,
       images,
       productOptionId,
+      option,
       options,
       amount,
       productId,

--- a/server/src/order/application/order-service.ts
+++ b/server/src/order/application/order-service.ts
@@ -20,7 +20,6 @@ export class OrderService {
   async findOrderByOrderNum(orderNum: number): Promise<OrderResponse[]> {
     try {
       const orders = await this.orders.findOrderByOrderNum(orderNum);
-      console.log("orders", orders);
       return orders.map(OrderResponse.of);
     } catch (e) {
       throw Error(e.message);

--- a/server/src/order/domain/orders.ts
+++ b/server/src/order/domain/orders.ts
@@ -27,7 +27,7 @@ export class Orders {
 
   async findOrderByOrderNum(orderNum: number) {
     return await this.orderRepository.find({
-      relations: ["user", "product", "product.images"],
+      relations: ["user", "product", "product.images", "product.options"],
       where: { orderNum },
     });
   }

--- a/server/src/order/dto/order-response.ts
+++ b/server/src/order/dto/order-response.ts
@@ -1,3 +1,4 @@
+import { Product } from "@/product/entity/product";
 import { OrderStatus } from "../entity/order";
 import { Order } from "../entity/order";
 
@@ -18,6 +19,7 @@ export class OrderResponse {
   image: string;
   optionName: string;
   optionValue: string;
+  product: Product;
 
   static of(order: Order): OrderResponse {
     const id = order.id,
@@ -33,6 +35,7 @@ export class OrderResponse {
       createdAt = order.createdAt,
       productName = order.product.name,
       reviewId = order.review ? order.review.id : 0,
+      product = order.product,
       image = order.product.images[0] ? order.product.images[0].id : "bed";
     let optionName = "",
       optionValue = "";
@@ -60,6 +63,7 @@ export class OrderResponse {
       productName,
       reviewId,
       image,
+      product,
       optionName,
       optionValue,
     };

--- a/server/src/payment/presentation/payment-controller.ts
+++ b/server/src/payment/presentation/payment-controller.ts
@@ -36,9 +36,9 @@ export class PaymentController {
       return {
         url: json.next_redirect_pc_url,
       };
-
-      //   Redirect(json.next_redirect_pc_url);
-    } catch (e) {}
+    } catch (e) {
+      throw Error(e.message);
+    }
   }
 
   @Get("/approve")
@@ -67,12 +67,14 @@ export class PaymentController {
       return json.aid
         ? {
             status: 301,
-            url: properties.client + "/order/success",
+            url: properties.client,
           }
         : {
             status: 500,
             message: "payment failed",
           };
-    } catch (e) {}
+    } catch (e) {
+      throw Error(e.message);
+    }
   }
 }


### PR DESCRIPTION
## :bookmark_tabs: 제목

주문 생성시 주문번호 생성  
주문내역 페이지 구현  
주문완료시 주문내역 페이지로 이동

![image](https://user-images.githubusercontent.com/50590192/131173871-6128e231-d96a-4ab6-ae34-fab8b15391ec.png)
![image](https://user-images.githubusercontent.com/50590192/131175615-81c96b66-3401-4820-b94f-a224c9c75f53.png)
![image](https://user-images.githubusercontent.com/50590192/131179430-1494f14c-ad55-467b-8a8d-6bfb40566018.png)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] order_num 프로퍼티 추가
- [x] 주문내역 페이지 마크업
- [x] 로그인페이지 주문번호로 조회하기
- [x] 마이페이지 내정보 수정 마크업 (기능X)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 주문번호 = YYMMDDHHmm + 함께 주문한 order들 중 하나의 아이디
