### PR TITLE
[FE] 아이템 좋아요 관련 버그 수정

### DIFF
--- a/client/src/api/products.ts
+++ b/client/src/api/products.ts
@@ -28,10 +28,12 @@ export const getAllProductsByKeyword = async (keyword: string) =>
 export const getProducts = async (
   params: ProductParams
 ): Promise<ProductElementType[]> => {
-  return await GET("/products", params);
+  return GET("/products", params);
 };
 export const useProducts = (params: ProductParams) =>
-  useQuery(["products", params], () => getProducts(params));
+  useQuery(["products", params], () => getProducts(params), {
+    cacheTime: 0,
+  });
 
 // GET /products/:id 상품 상세 정보
 const getProduct = (id: number): Promise<ProductType> => GET(`/products/${id}`);

--- a/client/src/utils/error/index.ts
+++ b/client/src/utils/error/index.ts
@@ -10,6 +10,7 @@ export const enum HttpStatus {
   NOT_FOUND = 404,
   NOT_ACCEPTABLE = 406,
   PROXY_AUTHENTICATION_REQUIRED = 407,
+  PRECONDITION_FAILED = 412,
 }
 
 interface ErrorResponse extends Response {
@@ -26,6 +27,7 @@ export const handleHttpError = (error: HttpError) => {
 
   switch (error.status) {
     case HttpStatus.UNAUTHORIZED:
+    case HttpStatus.PRECONDITION_FAILED:
       moveTo("/login");
       break;
     default:

--- a/server/src/jwt-middleware.ts
+++ b/server/src/jwt-middleware.ts
@@ -22,7 +22,6 @@ export class LoggerMiddleware implements NestMiddleware {
         req.body.userId = this.jwtService.decode(token)["userId"];
       }
     } catch (e) {
-      console.log(e.message);
       res.clearCookie(properties.auth.tokenKey);
       res.status(HttpStatus.PRECONDITION_FAILED);
       return { message: "토큰이 만료되었습니다" };


### PR DESCRIPTION
## :bookmark_tabs: 아이템 좋아요 관련 버그 수정

상세페이지에서 아이템 좋아요 상태를 변경하고 메인 페이지로 갔을 때 해당 데이터가 반영이 안되던 버그를 수정했습니다!

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

세번째 인자로 cashTome을 false로 줘서, API를 불러올 때 마다 캐싱 되지 않은 데이터를 불러오도록 했습니다..!

```javascript
export const useProducts = (params: ProductParams) =>
  useQuery(["products", params], () => getProducts(params), {
    cacheTime: 0,
  });
```

token expired의 status code를 412번 (PRECONDITION_FAILED)으로 변경했고, 해당 코드일 경우에, 클라이언트에서 로그인 페이지로 리디렉션 시켜주도록 변경했습니다.