### PR TITLE
[FE] convertToPhoneNumber 함수 string 없으면 빈 문자열 반환하도록 변경

### DIFF
--- a/client/src/Components/Input/ValidationInput/index.tsx
+++ b/client/src/Components/Input/ValidationInput/index.tsx
@@ -49,8 +49,9 @@ const ValidationInput = ({
               ? `${className} valid-input `
               : `${className} invalid-input`
           }
-          defaultValue={!!filter ? filter(input.value) : input.value}
+          value={!!filter ? filter(input.value) : input.value}
           onChange={(e) => {
+            console.log("a");
             onChange && onChange(e);
             input.onChange(e);
           }}
@@ -69,7 +70,7 @@ const ValidationInput = ({
               ? `${className} valid-input`
               : `${className} invalid-input`
           }
-          defaultValue={filter ? filter(input.value) : input.value}
+          value={filter ? filter(input.value) : input.value}
           onChange={(e) => {
             onChange && onChange(e);
             input.onChange(e);

--- a/client/src/Components/Input/ValidationInput/index.tsx
+++ b/client/src/Components/Input/ValidationInput/index.tsx
@@ -51,7 +51,6 @@ const ValidationInput = ({
           }
           value={!!filter ? filter(input.value) : input.value}
           onChange={(e) => {
-            console.log("a");
             onChange && onChange(e);
             input.onChange(e);
           }}

--- a/client/src/Pages/Main/ProductSection/index.tsx
+++ b/client/src/Pages/Main/ProductSection/index.tsx
@@ -14,11 +14,6 @@ const ProductSection = ({ title, type }: ProductSectionProps) => {
     size: MAIN_PAGE_PRODUCTS_SIZE,
     page: 1,
   });
-  console.log(product.data);
-  useEffect(() => {
-    // console.log(product.data, product.status);
-  }, [product]);
-
   return (
     <SectionWrapper {...{ title }}>
       <div className="title">{title}</div>

--- a/client/src/Pages/MyPage/ContentArea/contents/UserInfo/index.tsx
+++ b/client/src/Pages/MyPage/ContentArea/contents/UserInfo/index.tsx
@@ -7,11 +7,7 @@ import { gap } from "@/styles/theme";
 import { patchMe, useMyDestinations, useMyInfo } from "@/api/my";
 import useInput from "@/hooks/useInput";
 import { convertToNumber, convertToPhoneNumber } from "@/utils/util";
-import {
-  validateEmail,
-  validatePhoneNumber,
-  VALIDATION_ERR_MSG,
-} from "@/utils/validations";
+import { validatePhoneNumber, VALIDATION_ERR_MSG } from "@/utils/validations";
 import useValidation from "@/hooks/useValidation";
 import { DestinationType } from "@/shared/type";
 import AddressModal from "@/Pages/Order/AddressModal";
@@ -23,7 +19,7 @@ const UserInfo = () => {
 
   // form
   const name = useInput(myInfo?.name ?? "");
-  const phone = useInput(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
+  const phone = useInput(myInfo?.phoneNumber ?? "", convertToPhoneNumber);
   const nameValidation = useValidation((name: string) => !!name?.length);
   const phoneValidation = useValidation(validatePhoneNumber);
 

--- a/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
+++ b/client/src/Pages/Order/OrderContent/LoggedinContent.tsx
@@ -6,11 +6,7 @@ import { Arrow, ETPay, KakaoPay } from "@/assets";
 import InputSection from "@/Components/Input/InputSection";
 import useValidation from "@/hooks/useValidation";
 import ValidationInput from "@/Components/Input/ValidationInput";
-import {
-  validateEmail,
-  validatePhoneNumber,
-  VALIDATION_ERR_MSG,
-} from "@/utils/validations";
+import { validatePhoneNumber, VALIDATION_ERR_MSG } from "@/utils/validations";
 import { useMyDestinations, useMyInfo } from "@/api/my";
 import { DestinationType, ICart, PartialCart } from "@/shared/type";
 import CartOrderBox from "@/Components/CartOrderBox";
@@ -33,19 +29,15 @@ const LoggedinContent = () => {
   const { status: myInfoStatus, data: myInfo, error } = useMyInfo();
 
   // form
-  const email = useInput(myInfo?.email ?? "");
   const addressee = useInput(myInfo?.name ?? "");
-  const phone = useInput(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
-  const emailValidation = useValidation(validateEmail);
+  const phone = useInput(myInfo?.phoneNumber ?? "", convertToPhoneNumber);
   const nameValidation = useValidation((name: string) => !!name?.length);
   const phoneValidation = useValidation(validatePhoneNumber);
 
   useEffect(() => {
     if (myInfo) {
-      email.setValue(myInfo?.email);
       addressee.setValue(myInfo?.name);
-      phone.setValue(convertToPhoneNumber(myInfo?.phoneNumber));
-      emailValidation.onCheck(myInfo?.email ?? "");
+      phone.setValue(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
       nameValidation.onCheck(myInfo?.name ?? "");
       phoneValidation.onCheck(convertToPhoneNumber(myInfo?.phoneNumber ?? ""));
     }
@@ -83,11 +75,7 @@ const LoggedinContent = () => {
   };
 
   const isOrderable =
-    emailValidation.isValid &&
-    nameValidation.isValid &&
-    phoneValidation.isValid &&
-    !!payment &&
-    !!address;
+    nameValidation.isValid && phoneValidation.isValid && !!payment && !!address;
 
   return (
     myInfoStatus !== "loading" &&
@@ -117,14 +105,6 @@ const LoggedinContent = () => {
                   validation={nameValidation}
                   placeholder="이름"
                   message={VALIDATION_ERR_MSG.INVALID_NAME}
-                />
-              </InputSection>
-              <InputSection title="이메일">
-                <ValidationInput
-                  input={email}
-                  validation={emailValidation}
-                  placeholder="이메일을 입력해주세요"
-                  message={VALIDATION_ERR_MSG.INVALID_EMAIL}
                 />
               </InputSection>
               <InputSection

--- a/client/src/utils/util.ts
+++ b/client/src/utils/util.ts
@@ -91,7 +91,9 @@ export const convertToNumber = (str: string): string => {
   return str.replace(regex, "").substring(0, maxLength);
 };
 
-export const convertToPhoneNumber = (origin: string): string => {
+export const convertToPhoneNumber = (origin?: string): string => {
+  if (!origin) return "";
+
   //010-23O8-1O24
   const numbers = convertToNumber(origin);
 


### PR DESCRIPTION
## :bookmark_tabs: [FE] convertToPhoneNumber 함수 string 없으면 빈 문자열 반환하도록 변경

oAuth 간편 로그인을 통해서 회원가입을 했을 때, 기본 전화번호가 설정되어있지 않아 생기는 버그를 해결했습니다.

(작업 내역 확인하기 편하도록 gif 첨부)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] convertToPhoneNumber 함수 string 없으면 빈 문자열 반환하도록 변경
