### PR TITLE
[FE] 로그아웃 시, item wish box가 Refetch 안되던 버그 수정

### DIFF
--- a/client/src/Components/Item/index.tsx
+++ b/client/src/Components/Item/index.tsx
@@ -12,6 +12,7 @@ import useDidMountEffect from "@/hooks/useDidMountEffect";
 import { useRecoilValue } from "recoil";
 import { loginState } from "@/store/state";
 import { QueryObserverResult } from "react-query";
+import { useEffect } from "react";
 
 type ItemType = {
   id: number;
@@ -55,6 +56,10 @@ const Item = ({
     }
     setIsMyWish((isMyWish) => !isMyWish);
   };
+
+  useEffect(() => {
+    setIsMyWish(isWish);
+  }, [isWish]);
 
   useDidMountEffect(async () => {
     debounceIsMyWish ? await postWishProduct(id) : await deleteWishProduct(id);

--- a/client/src/Pages/Main/ProductSection/index.tsx
+++ b/client/src/Pages/Main/ProductSection/index.tsx
@@ -5,6 +5,7 @@ import { useProducts } from "@/api/products";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import { loginState } from "@/store/state";
+import { useCallback } from "react";
 
 export interface ProductSectionProps extends SectionType {}
 
@@ -17,9 +18,11 @@ const ProductSection = ({ title, type }: ProductSectionProps) => {
     size: MAIN_PAGE_PRODUCTS_SIZE,
     page: 1,
   });
+
   useEffect(() => {
     product.refetch();
   }, [isLoggedIn]);
+
   return (
     <SectionWrapper {...{ title }}>
       <div className="title">{title}</div>

--- a/client/src/Pages/Main/ProductSection/index.tsx
+++ b/client/src/Pages/Main/ProductSection/index.tsx
@@ -5,7 +5,6 @@ import { useProducts } from "@/api/products";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import { loginState } from "@/store/state";
-import { useCallback } from "react";
 
 export interface ProductSectionProps extends SectionType {}
 


### PR DESCRIPTION
## :bookmark_tabs: [FE] 로그아웃 시, item wish box가 Refetch 안되던 버그 수정

메인페이지에서 로그아웃 시, item wish UI가 변경되지 않던 버그를 수정했습니다 🙂

## 예상소요시간: 0.5H ##실제 소요시간: 1H
