### PR TITLE
feat: ES 인덱스 삭제 & 상품등록 버그 수정

### DIFF
--- a/client/src/Pages/Admin/Create/index.tsx
+++ b/client/src/Pages/Admin/Create/index.tsx
@@ -164,7 +164,7 @@ const AdminProductCreate: FC<Props> = ({ setPage }) => {
   };
 
   const addProduct = () => {
-    if (name && category && subCategory) {
+    if (name && category) {
       if (optionName) {
         const optionValid = options.reduce((acc, cur) => {
           if (cur.name) return acc && true;

--- a/server/src/product/application/product-service.ts
+++ b/server/src/product/application/product-service.ts
@@ -105,7 +105,7 @@ export class ProductService {
 
   async deleteProduct(id: number) {
     try {
-      //this.serachService.deleteProduct(id);
+      this.serachService.deleteProduct(id);
       await this.products.deleteProduct(id);
     } catch (e) {
       throw new Error(messages.failed.FAILED_TO_DELETE_PRODUCT);

--- a/server/src/product/application/search-service.ts
+++ b/server/src/product/application/search-service.ts
@@ -34,10 +34,11 @@ export class SearchService {
     try {
       await this.searchService.deleteByQuery({
         index: this.index,
+        type: this.type,
         body: {
           query: {
             match: {
-              id: id.toString(),
+              productId: id,
             },
           },
         },


### PR DESCRIPTION
## :bookmark_tabs: ES 인덱스 삭제 & 상품등록 버그 수정
이제부터 상품 삭제시 Elasticsearch 에서도 인덱스가 해제되어 검색에 노출되지 않습니다
상품 등록시 선물하기같은 서브 카테고리가 없는 상품을 추가하지 못하는 버그를 수정하였습니다

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 상품 삭제시 ES에서도 인덱스 삭제
- [x] 상품 등록 버그 수정
