### PR TITLE
[FE] 헤더 버그 수정!

### DIFF
--- a/client/src/Components/Header/Menu/index.tsx
+++ b/client/src/Components/Header/Menu/index.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { FlattenSimpleInterpolation } from "styled-components";
 import { getSiblingIndex } from "@/utils/node";
 import { Link } from "@/Router";
 import { categories } from "@/shared/dummy";
@@ -15,8 +15,6 @@ const Menu = () => {
   const selected = useRecoilValue(selectedCategoryState);
   const [hovered, setHoveredCategoryState] =
     useRecoilState(hoveredCategoryState);
-
-  const [padding, setPadding] = useRecoilState(categoryPaddingState);
 
   const checkChangeCategory = ({
     target,
@@ -37,14 +35,6 @@ const Menu = () => {
     return true;
   };
 
-  const getPadding = ($li: HTMLElement) => {
-    const left: number = $li.offsetLeft - $li.parentElement.offsetLeft;
-    const width: number = $li.offsetWidth;
-    const barWidth: number = $li.parentElement.offsetWidth;
-
-    setPadding(barWidth - 2 * left - width);
-  };
-
   const setHoveredCategoryId = (id) => {
     setHoveredCategoryState({
       ...hovered,
@@ -61,7 +51,6 @@ const Menu = () => {
 
     if (id !== hovered.categoryId) {
       setHoveredCategoryId(id);
-      getPadding($li);
     }
   };
 
@@ -84,26 +73,13 @@ const Menu = () => {
     </MainCategoryWrapper>
   );
 
-  const getWidth = (list: CategoryType[]): number => {
-    const CHAR_WIDTH = 10; //한 글자당 가로 크기: 10px (대충)
-    const PADDING = 60; //한 버튼당 가로 패딩이: 6rem
-
-    return (
-      list?.reduce(
-        (prev, curr) => prev + curr.name.length * CHAR_WIDTH + PADDING,
-        0
-      ) ?? 0
-    );
-  };
-
   const checkHideSubCategory =
     !categories[highlighted.categoryId / 100]?.subCategories.length &&
     !categories[selected.categoryId / 100]?.subCategories.length;
 
   const generateSubCategory = (
     <SubCategoryWrapper
-      padding={padding}
-      width={getWidth(categories[highlighted.categoryId / 100]?.subCategories)}
+      styleCss={categories[highlighted.categoryId / 100]?.style}
     >
       {categories[highlighted.categoryId / 100]?.subCategories?.map(
         (subCategory: CategoryType) => (
@@ -197,40 +173,15 @@ const MainCategoryWrapper = styled.ul`
   }
 `;
 
-/* Sub 카테고리가 메인 카테고리 가운데 오도록 padding 값을 구하는 함수!
- * 하지만 만약 Sub카테고리의 길이가 길어서 가운데 온다면 전체 영역을 벗어 나기 때문에
- * padding을 적용하지 않고 flex-start, flex-end로 제일 끝에 오도록 반영
- */
-const setPadding = (padding: number, width: number): string => {
-  const PADDING = 100; //100px;
-
-  const barWidth = window.innerWidth - PADDING;
-  const totalWidth = Math.abs(padding) + width;
-
-  // 가운데 위치해도 괜찮은 경우
-  if (totalWidth < barWidth) {
-    return padding > 0
-      ? `padding-right:${padding}px;`
-      : `padding-left:${Math.abs(padding)}px;`;
-  } else {
-    //길이가 길어서 가운데 위치 한다면 가릴 경우
-    return padding > 0
-      ? `justify-content: flex-start;`
-      : `justify-content: flex-end;`;
-  }
-};
-
-const SubCategoryWrapper = styled.ul<{
-  padding: number;
-  width: number;
-}>`
+const SubCategoryWrapper = styled.ul<{ styleCss: FlattenSimpleInterpolation }>`
   box-sizing: border-box;
   display: flex;
   justify-content: center;
   flex-direction: row;
   height: 3.6rem;
 
-  ${({ padding, width }) => setPadding(padding, width)}
+  ${({ styleCss }) => styleCss}
+
   ${media.mobile} {
     width: 100%;
     padding: 0;

--- a/client/src/Components/Header/Search/index.tsx
+++ b/client/src/Components/Header/Search/index.tsx
@@ -8,7 +8,6 @@ import { moveTo } from "@/Router";
 import { categories } from "@/shared/dummy";
 import { MainCategoryType } from "@/Pages/Category";
 import { Delete, Arrow } from "@/assets";
-import { media } from "@/styles/theme";
 
 const LS_SEARCH = "search";
 

--- a/client/src/Components/Header/Search/index.tsx
+++ b/client/src/Components/Header/Search/index.tsx
@@ -131,6 +131,7 @@ const SearchWrapper = styled.form`
     cursor: pointer;
 
     & > div {
+      width: calc(100% - 1rem);
       display: none;
       box-shadow: none;
       border: 1px solid ${({ theme }) => theme.color.primary1};
@@ -190,8 +191,8 @@ const SearchBox = styled.div`
   ${({ theme }) => theme.font.small}
   position: absolute;
   box-sizing: border-box;
-  width: 34rem;
   padding: 1rem;
+  max-width: calc(100% - 1rem);
   border: 1px solid ${({ theme }) => theme.color.light_grey2};
   background: ${({ theme }) => theme.color.white};
   .search-list__title {

--- a/client/src/Pages/Category/Banner/index.tsx
+++ b/client/src/Pages/Category/Banner/index.tsx
@@ -3,24 +3,23 @@ import { media } from "@/styles/theme";
 import { useState } from "react";
 import { useEffect } from "react";
 import styled, { css } from "styled-components";
-import Image from "@/Components/Common/Image";
-import { CategoryParamType, CategoryType, MainCategoryType } from "../";
+import { CategoryType, MainCategoryType } from "../";
 import { useRecoilValue } from "recoil";
 import { selectedCategoryState } from "@/store/category";
+import { moveTo } from "@/Router";
 
 interface CategoryInfo extends MainCategoryType {
   subCategoryName?: string;
 }
+
+const DEFAULT_CATEGORY_PATH = "/category?category=0";
 
 export const currentCategoryInfo = ({
   categoryId,
   subCategoryId,
 }): CategoryInfo => {
   const category: MainCategoryType = categories.find(
-    (category: MainCategoryType) => {
-      const result = category.id === categoryId;
-      return result;
-    }
+    (category: MainCategoryType) => category.id === categoryId
   );
 
   const subCategoryName = category?.subCategories.find(
@@ -37,7 +36,12 @@ const CategoryBanner = () => {
   const category = useRecoilValue(selectedCategoryState);
   const [info, setInfo] = useState(currentCategoryInfo(category));
   useEffect(() => {
-    setInfo(currentCategoryInfo(category));
+    const currentCategory = currentCategoryInfo(category);
+    if (currentCategory.name) {
+      setInfo(currentCategory);
+    } else {
+      moveTo(DEFAULT_CATEGORY_PATH);
+    }
   }, [category]);
 
   return (

--- a/client/src/Pages/Category/index.tsx
+++ b/client/src/Pages/Category/index.tsx
@@ -3,9 +3,9 @@ import Filter, { filters, FilterType } from "../../Components/Filter";
 import { Arrow } from "@/assets";
 import Header from "@/Components/Header";
 import { PageWrapper } from "@/shared/styled";
-import styled from "styled-components";
+import styled, { FlattenSimpleInterpolation } from "styled-components";
 import Footer from "@/Components/Footer";
-import { getProducts, useProducts } from "@/api/products";
+import { getProducts } from "@/api/products";
 import InfiniteScroll from "@/Components/ProductList/InfiniteScroll";
 import { media } from "@/styles/theme";
 import { useState } from "react";
@@ -21,6 +21,7 @@ export interface MainCategoryType extends CategoryType {
   fontColor?: string;
   font?: string;
   subCategories?: CategoryType[];
+  style?: FlattenSimpleInterpolation;
 }
 
 export type CategoryParamType = {

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -33,7 +33,7 @@ export const Router = ({ children }): ReactElement => {
     const params = decodeParams();
 
     setSelectedCategoryState({
-      categoryId: params.category ? parseInt(params.category) : 0,
+      categoryId: params.category ? parseInt(params.category) : -1,
       subCategoryId: params.subCategory && parseInt(params.subCategory),
     });
   };

--- a/client/src/shared/dummy.ts
+++ b/client/src/shared/dummy.ts
@@ -12,6 +12,7 @@ import {
   CategoryBanner8,
   CategoryBanner9,
 } from "@/assets";
+import { css } from "styled-components";
 
 export const IMAGE_DUMMY =
   "https://store.baemin.com/data/board/upload/goodsreview/eea0b21ff31b55a0";
@@ -21,7 +22,9 @@ export const categories: MainCategoryType[] = [
     id: 0,
     name: "전체",
     brief: "",
-    fontColor: "#333",
+    style: css`
+      color: #333;
+    `,
     backgroundImg: CategoryBanner0,
     subCategories: [],
   },
@@ -30,6 +33,9 @@ export const categories: MainCategoryType[] = [
     name: "문구",
     brief: "세상 하나뿐인 필통을 위해",
     fontColor: "#333",
+    style: css`
+      justify-content: flex-start;
+    `,
     backgroundImg: CategoryBanner1,
     subCategories: [
       {
@@ -51,6 +57,9 @@ export const categories: MainCategoryType[] = [
     name: "리빙",
     brief: "날 안 사고 살 수 있겠어?",
     fontColor: "#333",
+    style: css`
+      justify-content: flex-start;
+    `,
     backgroundImg: CategoryBanner2,
     subCategories: [
       {
@@ -75,6 +84,10 @@ export const categories: MainCategoryType[] = [
     id: 300,
     name: "책",
     brief: "쌓인만큼 교양이 쌓인다",
+    style: css`
+      padding-right: 550px;
+      justify-content: flex-center;
+    `,
     backgroundImg: CategoryBanner3,
     subCategories: [
       {
@@ -91,7 +104,10 @@ export const categories: MainCategoryType[] = [
     id: 400,
     name: "배민그린",
     brief: "내가 그린 지구 그림",
-    fontColor: "#32BF9A",
+    fontColor: "#32bf9a",
+    style: css`
+      padding-right: 338px;
+    `,
     backgroundImg: CategoryBanner4,
     subCategories: [
       {
@@ -116,8 +132,11 @@ export const categories: MainCategoryType[] = [
     id: 500,
     name: "ㅋㅋ에디션",
     brief: "즐겁게 살자구ㅋㅋ",
-    fontColor: "#555",
     font: "BMKIRANGHAERANG",
+    fontColor: "#555",
+    style: css`
+      padding-right: 108px;
+    `,
     backgroundImg: CategoryBanner5,
     subCategories: [
       {
@@ -148,6 +167,9 @@ export const categories: MainCategoryType[] = [
     brief: "여기는 영원히 아날로그야",
     font: "BMEULJIRO",
     fontColor: "#333",
+    style: css`
+      padding-left: 180px;
+    `,
     backgroundImg: CategoryBanner6,
     subCategories: [
       {
@@ -173,6 +195,9 @@ export const categories: MainCategoryType[] = [
     name: "배달이 친구들",
     brief: "만나서 반가워",
     fontColor: "#32BF9A",
+    style: css`
+      padding-left: 460px;
+    `,
     backgroundImg: CategoryBanner7,
     subCategories: [
       {

--- a/client/src/shared/type.ts
+++ b/client/src/shared/type.ts
@@ -1,3 +1,5 @@
+import { css } from "styled-components";
+
 export interface ReviewType {
   id: number;
   rate: number;
@@ -196,6 +198,9 @@ export enum OrderStatus {
 export const CATEGORY = {
   "문구": {
     code: 100,
+    style: css`
+      justify-content: flex-start;
+    `,
     list: [
       {
         id: 101,

--- a/server/src/config/properties/properties.ts
+++ b/server/src/config/properties/properties.ts
@@ -20,7 +20,7 @@ export default {
   },
   auth: {
     secret: process.env.JWT_SECRET || "",
-    expiresIn: process.env.JWT_EXPIRES_IN || "10s",
+    expiresIn: process.env.JWT_EXPIRES_IN || "12H",
     bearer: "Bearer ",
     saltRounds: 10,
     tokenKey: "token",


### PR DESCRIPTION
## :bookmark_tabs: 제목

헤더에서 발생하는 각종 버그를 수정했습니다.

<img width="1261" alt="스크린샷 2021-08-30 오후 3 57 24" src="https://user-images.githubusercontent.com/35447853/131298378-fc333466-1056-42ef-9b3a-93001525687b.png">
<img width="1257" alt="스크린샷 2021-08-30 오후 3 57 33" src="https://user-images.githubusercontent.com/35447853/131298390-5e0156f8-9309-4c8f-8bd4-6c07d162aca4.png">

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 메인화면에서 전체 카테고리 비활성화
- [x] 마우스 out 이벤트 발생 시, 현재 select 되어있는 카테고리의 padding 값을 직접 설정
- [x] search에서 내려오는 Dropdown width 조정

