### PR TITLE
[FIX] 헤더 시멘틱 변경 + 카테고리 이미지 고정!

### DIFF
--- a/client/src/Components/Header/index.tsx
+++ b/client/src/Components/Header/index.tsx
@@ -12,7 +12,7 @@ const Header = () => {
   );
 };
 
-const TopWrapper = styled.div`
+const TopWrapper = styled.header`
   box-shadow: 0 0 1rem 0.2rem rgba(0, 0, 0, 0.2);
   position: fixed;
   top: 0;

--- a/client/src/Pages/Category/Banner/index.tsx
+++ b/client/src/Pages/Category/Banner/index.tsx
@@ -49,7 +49,11 @@ const CategoryBanner = () => {
       <BGWrapper>
         <img src={info.backgroundImg} alt="배경 이미지" />
       </BGWrapper>
-      <Wrapper fontColor={info.fontColor} font={info.font}>
+      <Wrapper
+        fontColor={info.fontColor}
+        font={info.font}
+        img={info.backgroundImg}
+      >
         <div className="category-info">
           <h2 className="category-name">{info.name}</h2>
           <div className="category-info-side">
@@ -84,7 +88,7 @@ const BGWrapper = styled.div`
   }
 `;
 
-const Wrapper = styled.div<{ fontColor?: string; font?: string }>`
+const Wrapper = styled.div<{ fontColor?: string; font?: string; img?: string }>`
   width: 100vw;
   height: 30rem;
   overflow: hidden;
@@ -146,6 +150,13 @@ const Wrapper = styled.div<{ fontColor?: string; font?: string }>`
   }
   ${media.mobile} {
     height: 17rem;
+    ${({ img }) =>
+      img &&
+      css`
+        background-image: url(${img});
+      `};
+    background-position-x: 60%;
+    background-size: cover;
 
     .category-info {
       padding: 2rem 3rem;


### PR DESCRIPTION
## :bookmark_tabs: 헤더 시멘틱 변경 + 카테고리 이미지 고정!

![스크린샷 2021-08-31 오전 10 02 13](https://user-images.githubusercontent.com/35447853/131425080-58a57ee4-1060-47a4-b299-760d8d85c327.png)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 헤더 태그 시멘틱하게 변경
- [x] 반응형 카테고리 이미지 백그라운드로 불러오게 변경